### PR TITLE
Upgrade guide to GraalVM 1.0.0-rc7

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "io.micronaut:runtime"
 
     //tag::graal[]
-    compileOnly "com.oracle.substratevm:svm:GraalVM-1.0.0-rc6"
+    compileOnly "com.oracle.substratevm:svm:GraalVM-1.0.0-rc7"
     runtimeOnly "io.micronaut:graal"
     //end::graal[]
 

--- a/complete/gradle.properties
+++ b/complete/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=1.0.0.RC1
+micronautVersion=1.0.0.RC2

--- a/src/main/docs/guide/graal/installGraal.adoc
+++ b/src/main/docs/guide/graal/installGraal.adoc
@@ -2,14 +2,14 @@
 To start using GraalVM you should first install the GraalVM SDK via the
  https://www.graalvm.org/docs/getting-started/[Getting Started] instructions or using SDKman:
 
-.Installing GraalVM 1.0.0-rc6 with SDKman
+.Installing GraalVM 1.0.0-rc7 with SDKman
 [source,bash]
 ----
-$ sdk install java 1.0.0-rc6-graal
-$ sdk use java 1.0.0-rc6-graal
+$ sdk install java 1.0.0-rc7-graal
+$ sdk use java 1.0.0-rc7-graal
 ----
 
-Note the above commands install the `1.0.0-rc6` version, and may need to be altered depending on the current release
+Note the above commands install the `1.0.0-rc7` version, and may need to be altered depending on the current release
  available.
 
 WARNING: As of this writing, GraalVM is currently only available for Linux and Mac OS X systems.
@@ -23,7 +23,7 @@ Once you have installed the SDK you should make the `svm` dependency available v
 $ mvn install:install-file -Dfile=${JAVA_HOME}/jre/lib/svm/builder/svm.jar \
                            -DgroupId=com.oracle.substratevm \
                            -DartifactId=svm \
-                           -Dversion=GraalVM-1.0.0-rc6 \
+                           -Dversion=GraalVM-1.0.0-rc7 \
                            -Dpackaging=jar
 ----
 


### PR DESCRIPTION
GraalVM 1.0.0-rc7 has been released on 2018-10-03:

http://www.graalvm.org/docs/release-notes/#10-rc7

Closes #1