### PR TITLE
Updated the initial gradle wrapper version to match the version in th…

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
Gradle was set to 4.7 in the starter source but the `complete` directory has 4.10. 4.7 does not work with Java 11 whereas 4.10 does.