### PR TITLE
Reduce image size from 130MB to 65MB

### DIFF
--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -5,5 +5,5 @@ RUN native-image --no-server -cp build/libs/complete-*.jar
 
 FROM frolvlad/alpine-glibc
 EXPOSE 8080
-COPY --from=graalvm /home/app/micronaut-graal-app .
+COPY --from=graalvm /home/app/micronaut-graal-app/micronaut-graal-app .
 ENTRYPOINT ["./micronaut-graal-app"]


### PR DESCRIPTION
Lets copy only native image. We don't need jars and other build stuff