### PR TITLE
fix: ConferenceControllerTest, use junit5 imports/annotations

### DIFF
--- a/complete/src/test/java/example/micronaut/ConferenceControllerTest.java
+++ b/complete/src/test/java/example/micronaut/ConferenceControllerTest.java
@@ -1,27 +1,27 @@
 package example.micronaut;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.runtime.server.EmbeddedServer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ConferenceControllerTest {
 
     private static EmbeddedServer server;
     private static HttpClient client;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupServer() {
         server = ApplicationContext.run(EmbeddedServer.class); // <1>
         client = server.getApplicationContext().createBean(HttpClient.class, server.getURL()); // <2>
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopServer() {
         if (server != null) {
             server.stop();


### PR DESCRIPTION
I was unable to compile the ConferenceControllerTest as it was using junit4 annotations so I've upgraded it to use junit5 instead.