### PR TITLE
Update graalvm version in documentation

### DIFF
--- a/src/main/docs/guide/graal/creatingGraalImage.adoc
+++ b/src/main/docs/guide/graal/creatingGraalImage.adoc
@@ -48,11 +48,11 @@ We can see that the application starts in only 12ms.
 
 To build your native image without using Docker you need to install GraalVM SDK via the https://www.graalvm.org/docs/getting-started/[Getting Started] instructions or using SDKman:
 
-.Installing GraalVM 19.2.0 with SDKman
+.Installing GraalVM 19.2.0.1 with SDKman
 [source,bash]
 ----
-$ sdk install java 19.2.0-grl
-$ sdk use java 19.2.0-grl
+$ sdk install java 19.2.0.1-grl
+$ sdk use java 19.2.0.1-grl
 ----
 
 The `native-image` tool was extracted from the base GraalVM distribution. Currently it is available as an early adopter plugin. To install it, run:
@@ -68,7 +68,7 @@ $ gu install native-image # <1>
 .Building Graal native image
 [source,bash]
 ----
-$ sdk use java 19.2.0-grl
+$ sdk use java 19.2.0.1-grl
 $ ./gradlew assemble
 $ native-image --no-server -cp build/libs/complete-*-all.jar # <1>
 ----


### PR DESCRIPTION
On my linux distribution (arch linux : 5.3.1-arch1-1-ARCH), I was facing the following error :

> Error: Error compiling query code (in /tmp/SVM-935958463940110448/PosixDirectives.c). Compiler command  gcc /tmp/SVM-935958463940110448/PosixDirectives.c -o /tmp/SVM-935958463940110448/PosixDirectives output included error: /tmp/SVM-935958463940110448/PosixDirectives.c:693:101: error: ‘SIOCGSTAMP’ undeclared (first use in this function); did you mean ‘SIOCGRARP’?

As notice in [this quarkus ticket](https://github.com/quarkusio/quarkus/issues/3526), Fedora user should face the same issue. Upgrade Graalvm version has worked perfectly for me.