### PR TITLE
Upgrade Micronaut to 2.4.0

### DIFF
--- a/complete/gradle.properties
+++ b/complete/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=2.3.0
+micronautVersion=2.3.4

--- a/complete/gradle.properties
+++ b/complete/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=2.3.4
+micronautVersion=2.4.0


### PR DESCRIPTION
Fixes #24 - where the `complete` version of the app is not buildable.